### PR TITLE
patch documentation readme example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Add the plugin to the plugins array in your `gatsby-config.js`
 
 ```javascript
 {
-  resolve: `gatsby-remark-amp`,
+  resolve: `gatsby-plugin-google-amp`,
   options: {
     analytics: {
       type: 'gtag',


### PR DESCRIPTION
change the example config in the documentation readme.
throws an error when building with the currently available example.
this an error `Couldn't find the "gatsby-remark-amp" plugin declared`.