### PR TITLE
feature/rm @charset from styles

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -39,7 +39,10 @@ export const onPreRenderHTML = (
     const styles = headComponents.reduce((str, x) => {
       if (x.type === "style") {
         if (x.props.dangerouslySetInnerHTML) {
-          str += x.props.dangerouslySetInnerHTML.__html;
+          str += x.props.dangerouslySetInnerHTML.__html.replace(
+            /@charset[^;]*;/g,
+            ''
+          );
         }
       } else if (x.key && x.key === "TypographyStyle") {
         str = `${x.props.typography.toString()}${str}`;


### PR DESCRIPTION
Hello!

I had a problem of the following nature: @charset 'UTF-8' was specified in the third-party library's styles. These styles fell into the global. And the validation of amp pages was broken. So I added some code and during ssr the plugin removes any charset declaration.